### PR TITLE
Guard integer conversion on empty command output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,143 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
 
 \.idea/
-build/
-dist/
 
-python_telnet_vlc\.egg-info/
+# Visual Studio Code
+.vscode

--- a/python_telnet_vlc/vlctelnet.py
+++ b/python_telnet_vlc/vlctelnet.py
@@ -49,13 +49,14 @@ class VLCTelnet(object):
             raise ConnectionError("Could not connect to VLC. Make sure the Telnet interface is enabled and accessible.")
         # Login to VLC using password provided in the arguments
         self.tn.read_until(b"Password: ")
-        self.run_command(password)
+        self.run_command(password, False)
 
-    def run_command(self, command):
+    def run_command(self, command, log=True):
         """Run a command and return a list with the output lines."""
         # Put the command in a nice byte-encoded variable
         full_command = command.encode('utf-8') + b'\n'
-        _LOGGER.debug("Sending command: %s", command)
+        if log:
+            _LOGGER.debug("Sending command: %s", command)
         # Write out the command to telnet
         self.tn.write(full_command)
         # Get the command output, decode it, and split out the junk


### PR DESCRIPTION
## Changes

- Guard integer conversion in `get_length` and `get_time`. The command output will be an empty string if no stream is running.
- Update `.gitignore` for common Python files.
- Add debug logging of command to send and command output.

Let me know if you want me to split the PR, eg have the gitignore change in a separate PR.