### PR TITLE
Hotfix issue core 29184

### DIFF
--- a/python_telnet_vlc/vlctelnet.py
+++ b/python_telnet_vlc/vlctelnet.py
@@ -46,11 +46,13 @@ class VLCTelnet(object):
     """Conection to VLC using Telnet."""
 
     # Non commands
-    def __init__(self, host="localhost", password="admin", port=4212, connect=True, login=True):
+    def __init__(self, host="localhost", password="admin", port=4212, connect=True, login=True, retries=5):
         self.tn = telnetlib.Telnet()
         self.host = host
         self.port = port
         self.password = password
+        self.retries = retries
+
         if connect:
             self.connect()
         # Login to VLC using password provided in the arguments
@@ -96,15 +98,16 @@ class VLCTelnet(object):
             self.tn.write(b'\n')
             answer = self.tn.read_until(b'> ')
             if answer:
-                print(f'is_connected: answer obtained. Value: {answer}')
+                _LOGGER.debug("is_connected: answer obtained. Value: %s", answer)
                 return True
             else:
-                print(f'is_connected: failed to obtain answer. Value: {answer}')
+                _LOGGER.debug("is_connected: failed to obtain answer.")
                 return False
         except sockerr:
             return False
+
     def run_command(self, command):
-        return self.do_run_command(command, 5)
+        return self.do_run_command(command, self.retries)
 
     def do_send_string(self, string):
         """Run a command and return a list with the output lines."""


### PR DESCRIPTION
This hotfix is intended to fix the issue reported in:

https://github.com/home-assistant/core/issues/29184

The approach consists of performing a connection test by sending a CRLF to the vlc server and expecting the prompt, prior to attempting to send the command itself.

Whenever the test fails, the connection is retried, using the appropriate method.

I have tested the fix in my Home Assistant Core instance (core-2021.9.7)  with success against another device running the VLC daemon (VLC media player 3.0.11) with telnet enabled.

I can now call the media player repeatedly without issues. At regular intervals the media player does become unavailable (I'm guessing due to the VLC closing the session - this can be observed when connecting via the command line), but the client will automatically reconnect. Before the fix, once the BrokenPipe error would occur, the session would never be recovered.
